### PR TITLE
Support Windows Alt codes in time entry notes

### DIFF
--- a/frontend/src/dashboard/TimeEntryModal.tsx
+++ b/frontend/src/dashboard/TimeEntryModal.tsx
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 
-import { useEffect, useRef, useState, type FormEventHandler } from "react";
+import { useEffect, useRef, useState, type FormEventHandler, type KeyboardEvent } from "react";
 import { FormRow, Modal } from "../components/Modal";
 import { flatpickrDateFormat, formatDisplayDate, parseDisplayDate, type DateLanguage } from "./dateFormat";
 import type { TimeEntryFormState } from "./timeEntryTypes";
 import { labelWorkItemName } from "./workItemUtils";
+import { decodeWindowsAltCode, numpadDigitFromKeyboardEvent } from "./windowsAltCodeInput";
 
 type WorkItem = { id: number; name: string; parentId?: number | null; depth: number; status?: string };
 
@@ -60,6 +61,47 @@ declare global {
 export function TimeEntryModal({ error, form, isSaving, language, t, onChange, onClose, onSubmit, workItems }: TimeEntryModalProps) {
   const projects = workItems.filter((workItem) => workItem.parentId == null);
   const tasks = workItems.filter((workItem) => workItem.parentId === form.projectId);
+  const noteRef = useRef<HTMLTextAreaElement | null>(null);
+  const pendingWindowsAltCodeRef = useRef("");
+
+  function insertNoteCharacter(character: string, textarea: HTMLTextAreaElement) {
+    const selectionStart = textarea.selectionStart ?? textarea.value.length;
+    const selectionEnd = textarea.selectionEnd ?? selectionStart;
+    const nextDescription = textarea.value.slice(0, selectionStart) + character + textarea.value.slice(selectionEnd);
+    const nextCursor = selectionStart + character.length;
+    onChange({ ...form, description: nextDescription });
+    window.requestAnimationFrame(() => {
+      noteRef.current?.setSelectionRange(nextCursor, nextCursor);
+    });
+  }
+
+  function handleNoteKeyDown(event: KeyboardEvent<HTMLTextAreaElement>) {
+    if (!event.altKey) {
+      return;
+    }
+    const digit = numpadDigitFromKeyboardEvent(event);
+    if (!digit) {
+      return;
+    }
+    pendingWindowsAltCodeRef.current += digit;
+    event.preventDefault();
+  }
+
+  function handleNoteKeyUp(event: KeyboardEvent<HTMLTextAreaElement>) {
+    if (event.key !== "Alt" && event.code !== "AltLeft" && event.code !== "AltRight") {
+      return;
+    }
+    const digits = pendingWindowsAltCodeRef.current;
+    pendingWindowsAltCodeRef.current = "";
+    if (!digits) {
+      return;
+    }
+    event.preventDefault();
+    const character = decodeWindowsAltCode(digits);
+    if (character) {
+      insertNoteCharacter(character, event.currentTarget);
+    }
+  }
 
   return (
     <Modal
@@ -159,9 +201,15 @@ export function TimeEntryModal({ error, form, isSaving, language, t, onChange, o
       <FormRow label={t.note}>
         <textarea
           className="tab-form-control"
+          ref={noteRef}
           rows={4}
           value={form.description}
+          onBlur={() => {
+            pendingWindowsAltCodeRef.current = "";
+          }}
           onChange={(event) => onChange({ ...form, description: event.target.value })}
+          onKeyDown={handleNoteKeyDown}
+          onKeyUp={handleNoteKeyUp}
         />
       </FormRow>
     </Modal>

--- a/frontend/src/dashboard/windowsAltCodeInput.ts
+++ b/frontend/src/dashboard/windowsAltCodeInput.ts
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2026 Grobmeier Solutions GmbH. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const cp437Characters = [
+  "", "☺", "☻", "♥", "♦", "♣", "♠", "•", "◘", "○", "◙", "♂", "♀", "♪", "♫", "☼",
+  "►", "◄", "↕", "‼", "¶", "§", "▬", "↨", "↑", "↓", "→", "←", "∟", "↔", "▲", "▼",
+  " ", "!", "\"", "#", "$", "%", "&", "'", "(", ")", "*", "+", ",", "-", ".", "/",
+  "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", ":", ";", "<", "=", ">", "?",
+  "@", "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O",
+  "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z", "[", "\\", "]", "^", "_",
+  "`", "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o",
+  "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z", "{", "|", "}", "~", "⌂",
+  "Ç", "ü", "é", "â", "ä", "à", "å", "ç", "ê", "ë", "è", "ï", "î", "ì", "Ä", "Å",
+  "É", "æ", "Æ", "ô", "ö", "ò", "û", "ù", "ÿ", "Ö", "Ü", "¢", "£", "¥", "₧", "ƒ",
+  "á", "í", "ó", "ú", "ñ", "Ñ", "ª", "º", "¿", "⌐", "¬", "½", "¼", "¡", "«", "»",
+  "░", "▒", "▓", "│", "┤", "╡", "╢", "╖", "╕", "╣", "║", "╗", "╝", "╜", "╛", "┐",
+  "└", "┴", "┬", "├", "─", "┼", "╞", "╟", "╚", "╔", "╩", "╦", "╠", "═", "╬", "╧",
+  "╨", "╤", "╥", "╙", "╘", "╒", "╓", "╫", "╪", "┘", "┌", "█", "▄", "▌", "▐", "▀",
+  "α", "ß", "Γ", "π", "Σ", "σ", "µ", "τ", "Φ", "Θ", "Ω", "δ", "∞", "φ", "ε", "∩",
+  "≡", "±", "≥", "≤", "⌠", "⌡", "÷", "≈", "°", "∙", "·", "√", "ⁿ", "²", "■", " "
+];
+
+const windows1252ControlCharacters: Record<number, string> = {
+  128: "€",
+  130: "‚",
+  131: "ƒ",
+  132: "„",
+  133: "…",
+  134: "†",
+  135: "‡",
+  136: "ˆ",
+  137: "‰",
+  138: "Š",
+  139: "‹",
+  140: "Œ",
+  142: "Ž",
+  145: "‘",
+  146: "’",
+  147: "“",
+  148: "”",
+  149: "•",
+  150: "–",
+  151: "—",
+  152: "˜",
+  153: "™",
+  154: "š",
+  155: "›",
+  156: "œ",
+  158: "ž",
+  159: "Ÿ"
+};
+
+export function decodeWindowsAltCode(digits: string): string | null {
+  if (!digits) {
+    return null;
+  }
+  const codePoint = Number(digits);
+  if (!Number.isInteger(codePoint) || codePoint < 0 || codePoint > 0x10ffff) {
+    return null;
+  }
+  if (digits.startsWith("0")) {
+    if (codePoint < 32) {
+      return null;
+    }
+    return windows1252ControlCharacters[codePoint] ?? String.fromCodePoint(codePoint);
+  }
+  if (codePoint <= 255) {
+    return cp437Characters[codePoint] || null;
+  }
+  return String.fromCodePoint(codePoint);
+}
+
+export function numpadDigitFromKeyboardEvent(event: Pick<KeyboardEvent, "code" | "key">): string | null {
+  const codeMatch = /^Numpad([0-9])$/.exec(event.code);
+  if (codeMatch) {
+    return codeMatch[1];
+  }
+  if (/^[0-9]$/.test(event.key)) {
+    return event.key;
+  }
+  return null;
+}


### PR DESCRIPTION
Add Alt+Numpad character input support to the Time Entry note textarea. The modal now captures Alt-held numpad digits, decodes them on Alt release, and inserts the resulting character at the caret while preserving selection behavior. A new `windowsAltCodeInput` helper centralizes digit detection and Windows Alt-code decoding (CP437 for non-leading-zero input and Windows-1252 handling for leading-zero input).